### PR TITLE
docs: Fix installation of Brew in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ gcloud auth configure-docker
 ```
 sudo apt-get install build-essential procps curl file git 
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+```
 (echo; echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"') >> /home/user/.bashrc
 source ~/.bashrc 
 ```


### PR DESCRIPTION
When downloading Brew, the following line:
```
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
```
needs to be pasted into the terminal without any other command following it.
I believe this is because: when the command runs, it expected you to "Press RETURN/ENTER to continue or any other key to abort".

### Reproducing the error

* To reproduce the error, copy the entire block (all 4 lines) under the "Install Brew" step, and paste it into a terminal (inside Cloud Workstation).
* Notice how nothing happened after `Press RETURN/ENTER to continue or any other key to abort:` in the screenshot below.

![Screenshot 2023-12-11 at 1 09 13 PM](https://github.com/GoogleCloudPlatform/cymbal-superstore/assets/10292865/c35452fd-7596-4639-92c9-7cee23be543f)

### Working example

* See the screenshot below.
* This is me running the command without any other command following it. I had to press "return" ("Enter") to continue and Brew was actually installed.

![Screenshot 2023-12-11 at 1 12 09 PM](https://github.com/GoogleCloudPlatform/cymbal-superstore/assets/10292865/d3277897-e74c-487a-8aa4-1d6da2c4852b)

