### PR TITLE
docs: Set Artifact Registry region of auth command

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ gcloud config set project $PROJECT_ID
 4. Run the Docker auth credential helper. 
 
 ```
-gcloud auth configure-docker
+gcloud auth configure-docker us-central1-docker.pkg.dev
 ```
 
 5. Install brew.


### PR DESCRIPTION
* When I ran `terraform apply ...`, I got this error:
```
│ Error: local-exec provisioner error
...
│   with null_resource.docker_push_backend,
...
│ Error running command 'docker push us-central1-docker.pkg.dev/MY_PROJECT_ID/cymbal-superstore/inventory-api:79f565f204c41618': exit status 1. Output: The push refers to repository [us-central1-docker.pkg.dev/MY_PROJECT_ID/cymbal-superstore/inventory-api]
...
denied: Permission "artifactregistry.repositories.uploadArtifacts" denied on resource "projects/MY_PROJECT_ID/locations/us-central1/repositories/cymbal-superstore" (or it may not exist)
```
* According to [this StackOverflow post](https://stackoverflow.com/a/76078997), it's because we have to specify the exact regional Artifact Registry (AR) URL when adding Docker credentials for AR:
```
gcloud auth configure-docker us-central1-docker.pkg.dev
```
* I have tested this manually, and it worked. 👍 
