### PR TITLE
fix: Make Spanner database depend on API

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -285,6 +285,9 @@ resource "google_spanner_instance" "transactions" {
   config       = "regional-us-central1"
   display_name = "Cymbal Superstore Transactions"
   num_nodes    = 2
+  depends_on   = [
+    google_project_service.spanner
+  ]
 }
 
 


### PR DESCRIPTION
* When I ran `terraform apply`, the **creation of the Spanner database instance erred** because the Spanner API hadn't been enabled.
* (Sorry, I did not copy the error logs.)