### PR TITLE
Fix Cloud Run Terraform Deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ build/
 node_modules/
 jspm_packages/
 
+# NPM state
+*/package-lock.json
+
 # Distribution directories
 dist/
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ project_number="YOUR_PROJECT_NUMBER"
 
 ```
 
+Note: You can use `gcloud` to obtain your project number: `gcloud projects describe $PROJECT_ID --format="value(projectNumber)"`.
+
 9. Initialize Terraform. 
 
 ```

--- a/README.md
+++ b/README.md
@@ -97,11 +97,12 @@ brew install terraform
 cd cymbal-superstore/terraform
 ```
 
-8. In the `terraform/` directory, create a file called `terraform.tfvars`. Replace PROJECT_ID with your project ID, then save the file. 
+8. In the `terraform/` directory, create a file called `terraform.tfvars`. Replace PROJECT_ID and PROJECT_NUMBER with your project ID and project number, then save the file. 
 
 `terraform/terraform.tfvars`: 
 ```
 project_id="YOUR_PROJECT_ID"
+project_number="YOUR_PROJECT_NUMBER"
 
 ```
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -17,6 +17,11 @@ variable "project_id" {
   description = "Your Google Cloud project ID"
 }
 
+variable "project_number" {
+  type        = string
+  description = "Your Google Cloud project number"
+}
+
 variable "region" {
   type        = string
   description = "Your Google Cloud region"


### PR DESCRIPTION
This PR addresses two issues when deploying the Cloud Run service:
1. It grants sufficient IAM permissions to the base Cloud Run Service Account to talk to Firestore
2. Fixes the startup and liveness probe seconds

This PR also updates the .gitignore file to include the package-lock.json file that gets updated when building the frontend.